### PR TITLE
Add fix to circle animation, and update gitignore

### DIFF
--- a/peardrop_flutter/.gitignore
+++ b/peardrop_flutter/.gitignore
@@ -6,7 +6,10 @@
 .pub/
 build/
 ios/.generated/
+ios/Flutter/Generated.xcconfig
+ios/Flutter/flutter_export_environment.sh
 packages
 pubspec.lock
 .flutter-plugins
+.flutter-plugins-dependencies
 Podfile.lock

--- a/peardrop_flutter/lib/src/circle.dart
+++ b/peardrop_flutter/lib/src/circle.dart
@@ -95,19 +95,19 @@ class _CircleWaveRouteState extends State<CirclePage>
 
 class CircleWavePainter extends CustomPainter {
   final double waveRadius;
-  var wavePaint;
-  CircleWavePainter(this.waveRadius) {
-    wavePaint = Paint()
-      ..color = Colors.grey[200]
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2.0
-      ..isAntiAlias = true;
-  }
+  final Paint wavePaint = Paint()
+    ..color = Colors.grey[200]
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 2.0
+    ..isAntiAlias = true;
+
+  CircleWavePainter(this.waveRadius);
+
   @override
   void paint(Canvas canvas, Size size) {
-    double centerX = size.width / 2.0;
-    double centerY = size.height / 1.25;
-    double maxRadius = hypot(centerX, centerY);
+    double centerX = size.width * 0.5;
+    double centerY = size.height * 0.8;
+    double maxRadius = centerX * centerX + centerY * centerY;
 
     var currentRadius = waveRadius;
     while (currentRadius < maxRadius) {
@@ -119,9 +119,5 @@ class CircleWavePainter extends CustomPainter {
   @override
   bool shouldRepaint(CircleWavePainter oldDelegate) {
     return oldDelegate.waveRadius != waveRadius;
-  }
-
-  double hypot(double x, double y) {
-    return math.sqrt(x * x + y * y);
   }
 }


### PR DESCRIPTION
This makes the math in `circle.dart` a little bit simpler and easier to understand.

Also grepped the codebase for files that should not be checked into source control, and updated the gitignore appropriately.