### PR TITLE
Add ackpacket_get_type to C-API

### DIFF
--- a/peardrop_capi/include/peardrop.h
+++ b/peardrop_capi/include/peardrop.h
@@ -44,6 +44,13 @@ int32_t ackpacket_ext_tcp_update(ackpacket *packet, uint16_t port);
 void ackpacket_free(ackpacket *packet);
 
 /**
+ * Gets the type of this AckPacket. Caller's responsibility for freeing it.
+ *
+ * Returns NULL on error.
+ */
+acktype *ackpacket_get_type(const ackpacket *packet);
+
+/**
  * Creates an AckPacket from the given buffer.
  *
  * Returns NULL on error.

--- a/peardrop_capi/src/ad.rs
+++ b/peardrop_capi/src/ad.rs
@@ -39,7 +39,7 @@ pub extern "C" fn adpacket_ext_tcp_update(packet: *mut adpacket, port: u16) -> i
             match ext {
                 // TODO: It may be expensive to clone an extension, look into no-copy
                 AdExtension::TCP { ad_port: _ } => e = Some(ext.clone()),
-                _ => {},
+                _ => {}
             }
         }
         if let Some(e) = e {
@@ -64,10 +64,14 @@ pub extern "C" fn adpacket_ext_tcp_get(packet: *const adpacket, out_port: *mut u
     }
     // XXX: Not an unsafe block because let port is completely safe.
     let packet = unsafe { &*(packet as *const AdPacket) };
-    let port = packet.extensions.iter().find_map(|x| match x {
-        AdExtension::TCP { ad_port: port } => Some(*port),
-        _ => None,
-    }).unwrap_or_default();
+    let port = packet
+        .extensions
+        .iter()
+        .find_map(|x| match x {
+            AdExtension::TCP { ad_port: port } => Some(*port),
+            _ => None,
+        })
+        .unwrap_or_default();
     unsafe { *out_port = port };
     0
 }
@@ -76,7 +80,11 @@ pub extern "C" fn adpacket_ext_tcp_get(packet: *const adpacket, out_port: *mut u
 ///
 /// Returns non-zero on error.
 #[no_mangle]
-pub extern "C" fn adpacket_write(packet: *const adpacket, out_buf: *mut *mut u8, out_len: *mut usize) -> i32 {
+pub extern "C" fn adpacket_write(
+    packet: *const adpacket,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
     if packet.is_null() || out_buf.is_null() || out_len.is_null() {
         return 1;
     }

--- a/peardrop_capi/src/lib.rs
+++ b/peardrop_capi/src/lib.rs
@@ -17,7 +17,7 @@ fn write_vec(v_buf: Result<Vec<u8>, DekuError>, out_buf: *mut *mut u8, out_len: 
             };
             std::mem::forget(v);
             0
-        },
+        }
     }
 }
 

--- a/peardrop_capi/src/sender.rs
+++ b/peardrop_capi/src/sender.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::ffi::{CString, CStr};
+use std::ffi::{CStr, CString};
 
 pub type senderpacket = std::ffi::c_void;
 
@@ -21,7 +21,11 @@ pub extern "C" fn senderpacket_read(buf: *const u8, len: i32) -> *mut senderpack
 ///
 /// Returns NULL on error.
 #[no_mangle]
-pub extern "C" fn senderpacket_create(filename: *const u8, mimetype: *const u8, data_len: u64) -> *mut senderpacket {
+pub extern "C" fn senderpacket_create(
+    filename: *const u8,
+    mimetype: *const u8,
+    data_len: u64,
+) -> *mut senderpacket {
     if filename.is_null() || mimetype.is_null() {
         return std::ptr::null_mut();
     }
@@ -37,7 +41,12 @@ pub extern "C" fn senderpacket_create(filename: *const u8, mimetype: *const u8, 
     }
     let mimetype = mimetype.unwrap();
     // Create packet and return
-    let packet = SenderPacket::new(filename, mimetype, std::collections::HashSet::new(), data_len);
+    let packet = SenderPacket::new(
+        filename,
+        mimetype,
+        std::collections::HashSet::new(),
+        data_len,
+    );
     Box::into_raw(Box::new(packet)) as *mut _
 }
 
@@ -45,7 +54,11 @@ pub extern "C" fn senderpacket_create(filename: *const u8, mimetype: *const u8, 
 ///
 /// Returns non-zero on error.
 #[no_mangle]
-pub extern "C" fn senderpacket_write(packet: *const senderpacket, out_buf: *mut *mut u8, out_len: *mut usize) -> i32 {
+pub extern "C" fn senderpacket_write(
+    packet: *const senderpacket,
+    out_buf: *mut *mut u8,
+    out_len: *mut usize,
+) -> i32 {
     if packet.is_null() || out_buf.is_null() || out_len.is_null() {
         return 1;
     }
@@ -64,7 +77,10 @@ pub extern "C" fn senderpacket_free(packet: *mut senderpacket) {
 ///
 /// Returns non-zero on error.
 #[no_mangle]
-pub extern "C" fn senderpacket_get_data_length(packet: *const senderpacket, out_len: *mut u64) -> i32 {
+pub extern "C" fn senderpacket_get_data_length(
+    packet: *const senderpacket,
+    out_len: *mut u64,
+) -> i32 {
     if packet.is_null() || out_len.is_null() {
         return 1;
     }


### PR DESCRIPTION
This was some missing API surface from the C-API.

This is required in the Dart lib to get the type of an AckPacket read from a buffer.